### PR TITLE
Fixed energy overflow

### DIFF
--- a/include/dataflow.h
+++ b/include/dataflow.h
@@ -51,7 +51,7 @@ public:
 		isl_union_map* space_time_to_neighbor);
 	int GetL2Write(std::string tensor_name, AccessType type,
 		isl_union_map* space_time_to_neighbor);
-	int GetEnergy(isl_union_map* space_time_to_neighbor);
+	unsigned long long GetEnergy(isl_union_map* space_time_to_neighbor);
 
 	Dataflow copy() const;
 

--- a/src/dataflow.cpp
+++ b/src/dataflow.cpp
@@ -339,9 +339,9 @@ int Dataflow::GetL2Write(string tensor_name, AccessType type, isl_union_map *spa
                + GetUniqueVolume(tensor_name, AccessType::WRITE, space_time_to_neighbor);
 }
 
-int Dataflow::GetEnergy(isl_union_map *space_time_to_neighbor)
+unsigned long long Dataflow::GetEnergy(isl_union_map *space_time_to_neighbor)
 {
-    int energy           = GetMacNum();  // energy cost of MAC
+    unsigned long long energy           = GetMacNum();  // energy cost of MAC
     auto [input, output] = _st.GetTensorList();
     for (auto &iter : input) {
         energy += l1_multiplier * GetL1Read(iter, AccessType::READ);


### PR DESCRIPTION
TENET provides analysis for energy ([parameters come from maestro](https://github.com/pku-liang/TENET/blob/1a766b00147b5b45d403d72132df14562bceb0e8/include/stt.h#L25-L28)).
However, `Dataflow::GetEnergy` returns an overflow value since the data type of `energy` is `int`.

To reproduce the overflow bug, print `df.GetEnergy(isl_union_map_copy(space_time_to_neighbor));` in cli.cpp, and run the command from the [tutorial](https://pku-ahs.github.io/tutorial/en/master/_downloads/e59ee2860b8ed959a68a0c3f8b4ab308/tenet.pdf): 
```script
bin/tenet --m ./dataflow_example/KC_systolic_dataflow.m --p ./dataflow_example/pe_array.p --s ./dataflow_example/conv.s --o test.csv --all
``` 
You will get **Energy: -2147483648**.

With `unsigned int` or `unsigned long long`, you will get **Energy: 288686072**.
