### PR TITLE
GetComputationDelay: GetPENum -> GetAverageActivePENum

### DIFF
--- a/src/dataflow.cpp
+++ b/src/dataflow.cpp
@@ -247,7 +247,7 @@ int Dataflow::GetMacNumPerPE(int mac_per_instance)
     int mac_num = GetMacNum(mac_per_instance);
     // use GetSpaceDomain instead of pe.Getdomain() here in case some pes
     // are idle
-    int dsize = GetPENum();
+    int dsize = GetAverageActivePENum();
     return mac_num / dsize;
 }
 


### PR DESCRIPTION
Replace `GetPENum` with `GetAverageActivePENum` to get a more accurate result.
![image](https://user-images.githubusercontent.com/49781698/215481700-554edd43-256c-4ef1-a166-f6e2196a9775.png)
Ref.: https://dl.acm.org/doi/abs/10.1109/ISCA52012.2021.00062
* https://github.com/pku-liang/TENET/issues/3