### PR TITLE
Reversed time_to_neighbor

### DIFF
--- a/src/dataflow.cpp
+++ b/src/dataflow.cpp
@@ -248,7 +248,7 @@ int Dataflow::GetMacNumPerPE(int mac_per_instance)
     int mac_num = GetMacNum(mac_per_instance);
     // use GetSpaceDomain instead of pe.Getdomain() here in case some pes
     // are idle
-    int dsize = GetAverageActivePENum();
+    double dsize = GetAverageActivePENum();
     return mac_num / dsize;
 }
 

--- a/src/dataflow.cpp
+++ b/src/dataflow.cpp
@@ -115,6 +115,7 @@ isl_union_map *Dataflow::MapSpaceTimeToNeighbor(unsigned space_distance, bool sp
 {
     isl_union_map *space_to_neighbor      = MapSpaceToNeighbor(space_distance, space_is_range);
     isl_union_map *time_to_neighbor       = MapTimeToPrev(time_distance, time_is_range);
+    time_to_neighbor = isl_union_map_reverse(time_to_neighbor);
     isl_union_map *space_time_to_neighbor = isl_union_map_product(space_to_neighbor, time_to_neighbor);
     if (include_self == false) {
         isl_union_map *space_time_identity = isl_union_set_identity(GetSpaceTimeDomain());


### PR DESCRIPTION
@wangyuyue I think you should reverse the `time_to_neighbor` before passing it to `isl_union_map_product`.
Currently, TENET gets something like `[PE[0], T[1]] -> [PE[1] -> T[0]]`, but it is not possible to pass data from the current timestamp to the previous timestamp.